### PR TITLE
Add conflict detection for event tasks

### DIFF
--- a/src/main/java/chalk/Chalk.java
+++ b/src/main/java/chalk/Chalk.java
@@ -145,6 +145,18 @@ public class Chalk {
      * @param newTask The new task to be added
      */
     public void addTask(Task newTask) {
+
+        Optional<Task> conflictTask = this.taskList.checkConflict(newTask);
+
+        if (conflictTask.isPresent()) {
+            String message = """
+                    I cannot add this task! It conflicts with the following:
+                    %s
+                    """.formatted(conflictTask.get());
+            this.printError(message);
+            return;
+        }
+
         try {
             this.storage.addTask(newTask);
             this.taskList.addTask(newTask);

--- a/src/main/java/chalk/datetime/DateTime.java
+++ b/src/main/java/chalk/datetime/DateTime.java
@@ -3,6 +3,7 @@ package chalk.datetime;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Date;
 
 import chalk.storage.Storable;
 
@@ -50,5 +51,12 @@ public class DateTime implements Storable {
     public String toFileStorage() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
         return this.dateTime.format(formatter);
+    }
+
+    /**
+     * Returns True if the current DateTime is before the other one
+     */
+    public Boolean isBefore(DateTime otherDateTime) {
+        return this.dateTime.isBefore(otherDateTime.dateTime);
     }
 }

--- a/src/main/java/chalk/tasks/Event.java
+++ b/src/main/java/chalk/tasks/Event.java
@@ -53,4 +53,18 @@ public class Event extends Task {
                 + " /from " + this.startTime.toFileStorage() + " /to " + this.endTime.toFileStorage()
                 + super.toFileStorage();
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean checkConflict(Task otherTask) {
+        if (!(otherTask instanceof Event castedOtherTask)) {
+            // Currently, events can only conflict with other events
+            return false;
+        }
+
+        return this.startTime.isBefore(castedOtherTask.endTime) &&
+                castedOtherTask.startTime.isBefore(this.endTime);
+    }
 }

--- a/src/main/java/chalk/tasks/Task.java
+++ b/src/main/java/chalk/tasks/Task.java
@@ -52,6 +52,15 @@ public abstract class Task implements Storable {
     }
 
     /**
+     * Check if the current task conflicts with the other
+     * Currently, only relevant for events,
+     * so default implementation for other subclasses is to just return false
+     */
+    public boolean checkConflict(Task otherTask) {
+        return false;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/chalk/tasks/TaskList.java
+++ b/src/main/java/chalk/tasks/TaskList.java
@@ -2,6 +2,7 @@ package chalk.tasks;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import chalk.storage.Storable;
@@ -117,5 +118,18 @@ public class TaskList implements Storable {
         return this.taskList.stream()
                 .map(t -> t.toFileStorage() + "\n")
                 .reduce("", (a, b) -> a + b);
+    }
+
+    /**
+     * Checks through taskList to find if any event that conflicts with newTask (or vice versa)
+     * using their own checkConflict methods
+     *
+     * @return An optional containing the first conflicting task (if it exists)
+     * If there is no conflicting task, an empty optional is returned
+     */
+    public Optional<Task> checkConflict(Task newTask) {
+        return this.taskList.stream()
+                .filter(t -> t.checkConflict(newTask) || newTask.checkConflict(t))
+                .findFirst();
     }
 }


### PR DESCRIPTION
Currently, users can add event tasks that overlap with existing event tasks. This may lead to scheduling conflicts.

Update Chalk to automatically detect and prevent overlapping event tasks. This lets users manage their schedules more effectively It also tells them whch events clashes in the case of a conflict